### PR TITLE
Get path

### DIFF
--- a/sugar-backlight-helper
+++ b/sugar-backlight-helper
@@ -108,11 +108,17 @@ def _main():
                         default=None,
                         type=int,
                         help='Set the current brightness')
+    parser.add_argument('--get-path',
+                        dest="get_path",
+                        default=False,
+                        action='store_true',
+                        help='Get the path to brightness device')
 
     args = parser.parse_args()
     if args.get_brightness is False and \
        args.get_max_brightness is False and \
-       args.set_brightness is None:
+       args.set_brightness is None and \
+       args.get_path is False:
         print parser.error('No valid option was specified')
         return
 
@@ -123,6 +129,8 @@ def _main():
         print device.get_max_brightness()
     elif args.set_brightness is not None:
         device.set_brightness(int(args.set_brightness))
+    elif args.get_path is True:
+        print device.get_path()
 
 if __name__ == '__main__':
     _main()

--- a/sugar-backlight-helper
+++ b/sugar-backlight-helper
@@ -59,9 +59,12 @@ class Device:
             print 'Could not read from %s.' % path
             return None
 
-    def get_brightness(self):
+    def get_path(self):
         path = os.path.join(self._path, 'brightness')
-        return self._read_file(path)
+        return path
+
+    def get_brightness(self):
+        return self._read_file(self.get_path())
 
     def get_max_brightness(self):
         path = os.path.join(self._path, 'max_brightness')
@@ -80,7 +83,7 @@ class Device:
                 minimum = 0
             value = max(minimum, value)
 
-        path = os.path.join(self._path, 'brightness')
+        path = self.get_path()
         try:
             with open(path, 'w') as file:
                 file.write(str(value))


### PR DESCRIPTION
Provide a way for Sugar to get the path to the device, for use in polling for changes.  Use once at start of Sugar shell.  Untested.
